### PR TITLE
Editorial: Fixed a typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 (Partially.)
 
-ECMA-262 leaves the order of `for (a in b) ...` [almost totally unspecified](https://tc39.github.io/ecma262/#sec-enumerate-object-properties), but real engines tend to be consistent in at least some cases. Furthermore, over the years implementations have observed that anyone who wants to run code on the web needs to follow some contraints not captured by the spec.
+ECMA-262 leaves the order of `for (a in b) ...` [almost totally unspecified](https://tc39.github.io/ecma262/#sec-enumerate-object-properties), but real engines tend to be consistent in at least some cases. Furthermore, over the years implementations have observed that anyone who wants to run code on the web needs to follow some constraints not captured by the spec.
 
 This is a [stage 1 proposal](https://tc39.github.io/process-document/) to begin fixing that.
 


### PR DESCRIPTION
I found a possible typo in the README.md:
`contraints` -> `constraints`
Previously: `code on the web needs to follow some contraints`
Now: `code on the web needs to follow some constraints`

If the proposed changes aren't needed please let me know and I'll close the PR (^_^)
