### PR TITLE
Rephrase in terms of properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ See the [exploration](exploration/) directory for background and test cases from
 From [this list of interop semantics](exploration#interop-semantics) we can derive a conservative underapproximation of cases where engines already agree, which I believe covers the most common common cases. Specifically:
 
 - Neither the object being iterated nor anything in its prototype chain is exotic, except for Array exotic objects.
-- Neither the object being iterated nor anything in its prototype has their `[[SetPrototypeOf]]` or `[[Delete]]` methods called during iteration.
-- Nothing in the object's prototype chain has its `[[DefineOwnProperty]]` method called during iteration.
-- No property of the object itself has its enumerability change during iteration.
+- Neither the object nor anything in its prototype has its prototype change during iteration.
+- Neither the object nor anything in its prototype has a property deleted during iteration.
+- Nothing in the object's prototype chain has a property added during iteration.
+- No property of the object or anything in its prototype chain has its enumerability change during iteration.
 - No non-enumerable property shadows an enumerable one.
 
 All but the last are fairly easy to specify in prose; the last is somewhat harder. As far as I know JavaScriptCore is the only engine which will output anything in [this case](exploration/enumerable-shadowed.js), because of [this longstanding bug](https://bugs.webkit.org/show_bug.cgi?id=38970), so I am hopeful that point can be discarded.

--- a/index.html
+++ b/index.html
@@ -1821,10 +1821,10 @@ li.menu-search-result-term:before {
   <p>Enumerating the properties of the target object includes enumerating properties of its prototype, and the prototype of the prototype, and so on, recursively; but a property of a prototype is not processed if it has the same name as a property that has already been processed by the iterator's <code>next</code> method. The values of [[Enumerable]] attributes are not considered when determining if a property of a prototype object has already been processed. The enumerable property names of prototype objects must be obtained by invoking EnumerateObjectProperties passing the prototype object as the argument. EnumerateObjectProperties must obtain the own property keys of the target object by calling its [[OwnPropertyKeys]] internal method. Property attributes of the target object must be obtained by calling its [[GetOwnProperty]] internal method.</p>
   <p><ins>In addition, if neither <var>O</var> nor any object in its prototype chain is an exotic object other than an Array exotic object, then the iterator must behave as if it were the iterator given by <emu-xref aoid="CreateForInIterator" id="_ref_5"><a href="#sec-createforiniterator">CreateForInIterator</a></emu-xref> ( <var>O</var> ) until one of the following occurs:</ins></p>
   <ul>
-    <li><ins><var>O</var> or an object in its prototype chain has its [[SetPrototypeOf]] internal method invoked,</ins></li>
-    <li><ins><var>O</var> or an object in its prototype chain has its [[Delete]] internal method invoked,</ins></li>
-    <li><ins>an object in <var>O</var>'s prototype chain has its [[DefineOwnProperty]] internal method invoked, or</ins></li>
-    <li><ins><var>O</var> has its [[DefineOwnProperty]] internal method invoked with arguments <var>P</var> and <var>Desc</var> such that, at the point of invocation, <var>O</var> has an own property with key <var>P</var> and the value of the [[Enumerable]] attribute of that property is not the same as the value of <var>Desc</var>.[[Enumerable]].</ins></li>
+    <li><ins>the value of the [[Prototype]] internal slot of <var>O</var> or an object in its prototype chain changes,</ins></li>
+    <li><ins>a property is removed from <var>O</var> or an object in its prototype chain,</ins></li>
+    <li><ins>a property is added to an object in <var>O</var>'s prototype chain, or</ins></li>
+    <li><ins>the value of the [[Enumerable]] attribute of a property of <var>O</var> or an object in its prototype chain changes.</ins></li>
   </ul>
 
   <emu-note><span class="note">Note 1</span><div class="note-contents"><ins>

--- a/spec.html
+++ b/spec.html
@@ -25,10 +25,10 @@ contributors: Kevin Gibbons
   <p>Enumerating the properties of the target object includes enumerating properties of its prototype, and the prototype of the prototype, and so on, recursively; but a property of a prototype is not processed if it has the same name as a property that has already been processed by the iterator's `next` method. The values of [[Enumerable]] attributes are not considered when determining if a property of a prototype object has already been processed. The enumerable property names of prototype objects must be obtained by invoking EnumerateObjectProperties passing the prototype object as the argument. EnumerateObjectProperties must obtain the own property keys of the target object by calling its [[OwnPropertyKeys]] internal method. Property attributes of the target object must be obtained by calling its [[GetOwnProperty]] internal method.</p>
   <p><ins>In addition, if neither _O_ nor any object in its prototype chain is an exotic object other than an Array exotic object, then the iterator must behave as if it were the iterator given by CreateForInIterator ( _O_ ) until one of the following occurs:</ins></p>
   <ul>
-    <li><ins>_O_ or an object in its prototype chain has its [[SetPrototypeOf]] internal method invoked,</ins></li>
-    <li><ins>_O_ or an object in its prototype chain has its [[Delete]] internal method invoked,</ins></li>
-    <li><ins>an object in _O_'s prototype chain has its [[DefineOwnProperty]] internal method invoked, or</ins></li>
-    <li><ins>_O_ has its [[DefineOwnProperty]] internal method invoked with arguments _P_ and _Desc_ such that, at the point of invocation, _O_ has an own property with key _P_ and the value of the [[Enumerable]] attribute of that property is not the same as the value of _Desc_.[[Enumerable]].</ins></li>
+    <li><ins>the value of the [[Prototype]] internal slot of _O_ or an object in its prototype chain changes,</ins></li>
+    <li><ins>a property is removed from _O_ or an object in its prototype chain,</ins></li>
+    <li><ins>a property is added to an object in _O_'s prototype chain, or</ins></li>
+    <li><ins>the value of the [[Enumerable]] attribute of a property of _O_ or an object in its prototype chain changes.</ins></li>
   </ul>
 
   <emu-note><ins>


### PR DESCRIPTION
Rephrase in terms of properties rather than of MOP operations: those operations, on [ordinary objects](https://tc39.es/ecma262/#sec-object-type), ultimately boil down to manipulation of properties directly. For example, the crucial step in [OrdinaryDelete](https://tc39.es/ecma262/#sec-ordinarydelete) is "Remove the own property with name _P_ from _O_."

Since these are, by construction, ordinary objects, I think it's clearer to speak of the properties directly rather than the MOP operations which might manipulate them.